### PR TITLE
Improve Wayland integration and clean configuration

### DIFF
--- a/home/ion/default.nix
+++ b/home/ion/default.nix
@@ -7,5 +7,6 @@
     ./kitty.nix
     ./vscode.nix
     ./powermenu.nix
+    ./gtk.nix
   ];
 }

--- a/home/ion/gtk.nix
+++ b/home/ion/gtk.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+{
+  gtk = {
+    enable = true;
+    theme = {
+      package = pkgs.adw-gtk3;
+      name = "adw-gtk3";
+    };
+    iconTheme = {
+      package = pkgs.papirus-icon-theme;
+      name = "Papirus";
+    };
+  };
+}

--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -17,6 +17,12 @@
   time.timeZone = "Europe/Paris";
   networking.networkmanager.enable = true;
 
+  # Portal for Wayland apps
+  xdg.portal = {
+    enable = true;
+    extraPortals = with pkgs; [ xdg-desktop-portal-gtk ];
+  };
+
   # User
   users.users.ion = {
     isNormalUser = true;
@@ -39,6 +45,8 @@
   # Bootloader
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
+  boot.plymouth.enable = true;
+  boot.plymouth.theme = "bgrt";
 
   system.stateVersion = "25.05";
 }

--- a/modules/desktop/hyprland.nix
+++ b/modules/desktop/hyprland.nix
@@ -6,7 +6,5 @@
     xwayland.enable = true;
   };
 
-  # Removable media / trash / network mounts, etc.
-  services.gvfs.enable = true;
-  services.udisks2.enable = true;
+  # Removable media / trash / network mounts are configured globally
 }

--- a/modules/programs/common.nix
+++ b/modules/programs/common.nix
@@ -16,8 +16,6 @@
     grim
     slurp
     pamixer
-    pavucontrol
-    where-is-my-sddm-theme
 
     # File manager
     pkgs.xfce.thunar

--- a/modules/services/login/sddm.nix
+++ b/modules/services/login/sddm.nix
@@ -1,10 +1,11 @@
-{ ... }:
+{ pkgs, ... }:
 {
   services.displayManager = {
     sddm = {
       enable = true;
       wayland.enable = true;
       theme = "where_is_my_sddm_theme";
+      themePackage = pkgs.where-is-my-sddm-theme;
     };
     # Start Hyprland by default
     defaultSession = "hyprland";


### PR DESCRIPTION
## Summary
- remove duplicate packages and move SDDM theme into its module
- configure XDG portal and Plymouth for better Wayland and boot experience
- add GTK theme and Papirus icons to improve Thunar appearance

## Testing
- `nix --version` *(fails: command not found)*
- `sh <(curl -L https://nixos.org/nix/install) --no-daemon` *(fails: installing Nix as root is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a123e3137c83288469e8011403a0b0