### PR TITLE
Improve login and GTK theming

### DIFF
--- a/home/ion/default.nix
+++ b/home/ion/default.nix
@@ -7,5 +7,6 @@
     ./kitty.nix
     ./vscode.nix
     ./powermenu.nix
+    ./gtk.nix
   ];
 }

--- a/home/ion/gtk.nix
+++ b/home/ion/gtk.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+{
+  gtk = {
+    enable = true;
+    theme = {
+      name = "Adwaita-dark";
+    };
+    iconTheme = {
+      name = "Papirus-Dark";
+      package = pkgs.papirus-icon-theme;
+    };
+  };
+}

--- a/modules/desktop/hyprland.nix
+++ b/modules/desktop/hyprland.nix
@@ -5,8 +5,4 @@
     enable = true;
     xwayland.enable = true;
   };
-
-  # Removable media / trash / network mounts, etc.
-  services.gvfs.enable = true;
-  services.udisks2.enable = true;
 }

--- a/modules/programs/common.nix
+++ b/modules/programs/common.nix
@@ -16,18 +16,17 @@
     grim
     slurp
     pamixer
-    pavucontrol
-    where-is-my-sddm-theme
 
     # File manager
-    pkgs.xfce.thunar
-    pkgs.xfce.thunar-archive-plugin
-    pkgs.xfce.thunar-volman
-    pkgs.xfce.tumbler
+    xfce.thunar
+    xfce.thunar-archive-plugin
+    xfce.thunar-volman
+    xfce.tumbler
 
     # Applets
     pavucontrol
     networkmanagerapplet
+    papirus-icon-theme
 
     # ---- CLI utilities ----
     git

--- a/modules/services/login/sddm.nix
+++ b/modules/services/login/sddm.nix
@@ -1,10 +1,11 @@
-{ ... }:
+{ pkgs, ... }:
 {
   services.displayManager = {
     sddm = {
       enable = true;
       wayland.enable = true;
-      theme = "where_is_my_sddm_theme";
+      theme = "catppuccin-mocha";
+      extraPackages = [ pkgs.catppuccin-sddm ];
     };
     # Start Hyprland by default
     defaultSession = "hyprland";


### PR DESCRIPTION
## Summary
- Remove unused packages and duplicate services
- Use Catppuccin SDDM theme for a nicer login screen
- Configure Papirus icons and Adwaita theme for Thunar on Wayland

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake check`

------
https://chatgpt.com/codex/tasks/task_e_68a123e3137c83288469e8011403a0b0