### PR TITLE
Improve desktop configuration and login theme

### DIFF
--- a/modules/desktop/hyprland.nix
+++ b/modules/desktop/hyprland.nix
@@ -9,4 +9,5 @@
   # Removable media / trash / network mounts, etc.
   services.gvfs.enable = true;
   services.udisks2.enable = true;
+  services.tumbler.enable = true;
 }

--- a/modules/programs/common.nix
+++ b/modules/programs/common.nix
@@ -1,9 +1,6 @@
 { pkgs, ... }:
-
 {
   programs.firefox.enable = true;
-  services.gvfs.enable = true;
-  services.udisks2.enable = true;
 
   # System-wide packages for all users
   environment.systemPackages = with pkgs; [
@@ -17,7 +14,7 @@
     slurp
     pamixer
     pavucontrol
-    where-is-my-sddm-theme
+    sddm-chili-theme
 
     # File manager
     pkgs.xfce.thunar
@@ -26,7 +23,6 @@
     pkgs.xfce.tumbler
 
     # Applets
-    pavucontrol
     networkmanagerapplet
 
     # ---- CLI utilities ----

--- a/modules/services/login/sddm.nix
+++ b/modules/services/login/sddm.nix
@@ -4,7 +4,7 @@
     sddm = {
       enable = true;
       wayland.enable = true;
-      theme = "where_is_my_sddm_theme";
+      theme = "chili";
     };
     # Start Hyprland by default
     defaultSession = "hyprland";


### PR DESCRIPTION
## Summary
- clean up duplicate system packages and remove redundant services
- enable tumbler for better Thunar thumbnails
- switch SDDM to the chili theme for a nicer login screen

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake check`

------
https://chatgpt.com/codex/tasks/task_e_68a123e3137c83288469e8011403a0b0