### PR TITLE
refactor package placement

### DIFF
--- a/home/ion/default.nix
+++ b/home/ion/default.nix
@@ -10,5 +10,7 @@
     ./vscode.nix
     ./powermenu.nix
     ./wofi.nix
+    ./packages.nix
+    ./gaming.nix
   ];
 }

--- a/home/ion/gaming.nix
+++ b/home/ion/gaming.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    heroic
+    mangohud
+    goverlay
+    protonup-qt
+  ];
+}

--- a/home/ion/hyprland.nix
+++ b/home/ion/hyprland.nix
@@ -1,5 +1,17 @@
 { config, pkgs, ... }:
 {
+  home.packages = with pkgs; [
+    hyprpaper
+    wl-clipboard
+    grim
+    slurp
+    pamixer
+    swayosd
+    pavucontrol
+    libcanberra-gtk3
+    networkmanagerapplet
+  ];
+
   wayland.windowManager.hyprland = {
     enable = true;
     xwayland.enable = true;

--- a/home/ion/packages.nix
+++ b/home/ion/packages.nix
@@ -1,0 +1,13 @@
+{ pkgs, ... }:
+{
+  home.packages = with pkgs; [
+    git
+    curl
+    nvme-cli
+    unzip
+    fastfetch
+    vulkan-tools
+    nvtopPackages.amd
+    btop
+  ];
+}

--- a/modules/programs/common.nix
+++ b/modules/programs/common.nix
@@ -1,35 +1,5 @@
-{ pkgs, ... }:
+{ ... }:
 {
   programs.firefox.enable = true;
   programs.hyprland.enable = true;
-
-  # System-wide packages for all users
-  environment.systemPackages = with pkgs; [
-    # Desktop essentials
-    hyprpaper
-    waybar
-    wofi
-    kitty
-    wl-clipboard
-    grim
-    slurp
-    pamixer
-    swayosd
-    pavucontrol
-    sddm-chili-theme
-    libcanberra-gtk3
-
-    # Applets
-    networkmanagerapplet
-
-    # CLI utilities
-    git
-    curl
-    nvme-cli
-    unzip
-    fastfetch
-    vulkan-tools
-    nvtopPackages.amd
-    btop
-  ];
 }

--- a/modules/programs/gaming.nix
+++ b/modules/programs/gaming.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ ... }:
 {
   programs.steam = {
     enable = true;
@@ -6,11 +6,4 @@
     remotePlay.openFirewall = true;
     dedicatedServer.openFirewall = true;
   };
-
-  environment.systemPackages = with pkgs; [
-    heroic
-    mangohud
-    goverlay
-    protonup-qt
-  ];
 }

--- a/modules/services/login/sddm.nix
+++ b/modules/services/login/sddm.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ pkgs, ... }:
 {
   services.displayManager = {
     sddm = {
@@ -9,6 +9,6 @@
     # Start Hyprland by default
     defaultSession = "hyprland";
   };
+  environment.systemPackages = [ pkgs.sddm-chili-theme ];
   services.dbus.enable = true;
-
 }


### PR DESCRIPTION
## Summary
- move user-specific packages into Home Manager modules
- trim global packages and keep SDDM theme system-wide
- add dedicated gaming and utility package modules

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake check` *(fails: interrupted by the user)*

------
https://chatgpt.com/codex/tasks/task_e_68a499626fa88328845bda6d0e0e599a