### PR TITLE
Enable 32-bit graphics drivers for Steam

### DIFF
--- a/modules/programs/gaming.nix
+++ b/modules/programs/gaming.nix
@@ -6,4 +6,9 @@
     remotePlay.openFirewall = true;
     dedicatedServer.openFirewall = true;
   };
+
+  hardware.graphics = {
+    enable = true;
+    enable32Bit = true;
+  };
 }


### PR DESCRIPTION
## Summary
- enable 32-bit graphics drivers to improve Steam compatibility

## Testing
- `nix --extra-experimental-features "nix-command flakes" flake check --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68c4a72b569c8328893d3e150b91249a