### PR TITLE
Ensure Waybar shows four workspaces on startup

### DIFF
--- a/home/ion/hyprland.nix
+++ b/home/ion/hyprland.nix
@@ -68,7 +68,7 @@
         "hyprpaper"
         "waybar"
         "nm-applet --indicator"
-        "hyprctl dispatch workspace 1"
+        "bash -lc 'for ws in 1 2 3 4; do hyprctl dispatch workspace $ws; done; hyprctl dispatch workspace 1'"
       ];
 
       # Multimedia keys

--- a/home/ion/hyprland.nix
+++ b/home/ion/hyprland.nix
@@ -68,6 +68,7 @@
         "hyprpaper"
         "waybar"
         "nm-applet --indicator"
+        "hyprctl dispatch workspace 1"
       ];
 
       # Multimedia keys

--- a/home/ion/waybar.nix
+++ b/home/ion/waybar.nix
@@ -150,7 +150,7 @@
         };
 
         "hyprland/workspaces" = {
-          persistent_workspaces = { "*" = [ "1" "2" "3" "4" ]; };
+          persistent_workspaces = { "*" = [ 1 2 3 4 ]; };
           on-click = "hyprctl dispatch workspace {name}";
           format = "{icon}";
           format-icons = { default = "●"; active = "●"; urgent = "●"; };


### PR DESCRIPTION
## Summary
- enforce workspace 1 selection on Hyprland start
- clarify Waybar's persistent workspace list with numeric values

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake check`


------
https://chatgpt.com/codex/tasks/task_e_68c4b05de1148328ac3727bb6bd4adb2