### PR TITLE
Switch to animated SDDM theme with HiDPI support

### DIFF
--- a/modules/programs/common.nix
+++ b/modules/programs/common.nix
@@ -7,7 +7,7 @@
     curl
     nvme-cli
     unzip
-    sddm-chili-theme
+    sddm-astronaut
 
     (python3.withPackages (ps: with ps; [
       numpy

--- a/modules/services/login/sddm.nix
+++ b/modules/services/login/sddm.nix
@@ -4,7 +4,12 @@
     sddm = {
       enable = true;
       wayland.enable = true;
-      theme = "chili";
+      theme = "astronaut";
+      settings = {
+        General = {
+          EnableHiDPI = true;
+        };
+      };
     };
     # Start Hyprland by default
     defaultSession = "hyprland";


### PR DESCRIPTION
## Summary
- replace chili SDDM login theme with animated astronaut variant
- enable HiDPI scaling for SDDM
- update system packages accordingly

## Testing
- `nix --extra-experimental-features 'nix-command flakes' flake check`

------
https://chatgpt.com/codex/tasks/task_e_68c51f5aaa308328809a857944d8a471